### PR TITLE
Patch/addl tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -115,7 +115,7 @@ ubtu22cis_rule_1_3_2: true
 ubtu22cis_rule_1_4_1: true
 ubtu22cis_rule_1_4_2: true
 ubtu22cis_rule_1_4_3: true
-ubtu22cis_rule_1_4_4: true
+ubtu22cis_rule_1_4_4: false
 ubtu22cis_rule_1_5_1: true
 ubtu22cis_rule_1_5_2: true
 ubtu22cis_rule_1_5_3: true

--- a/tasks/section_3/cis_3.3.x.yml
+++ b/tasks/section_3/cis_3.3.x.yml
@@ -174,6 +174,7 @@
             state: present
             ignoreerrors: yes
             sysctl_file: "/etc/sysctl.d/10-network-security.conf"
+            reload: false
         with_items:
             - net.ipv4.conf.all.rp_filter
             - net.ipv4.conf.default.rp_filter
@@ -184,6 +185,7 @@
             state: present
             ignoreerrors: yes
             sysctl_file: "/usr/lib/sysctl.d/50-default.conf"
+            reload: false
         with_items:
             - net.ipv4.conf.all.rp_filter
             - net.ipv4.conf.default.rp_filter
@@ -194,6 +196,7 @@
             state: present
             ignoreerrors: yes
             sysctl_file: "/lib/sysctl.d/50-default.conf"
+            reload: false
         with_items:
             - net.ipv4.conf.all.rp_filter
             - net.ipv4.conf.default.rp_filter

--- a/tasks/section_3/cis_3.3.x.yml
+++ b/tasks/section_3/cis_3.3.x.yml
@@ -167,13 +167,33 @@
 
 - name: "3.3.7 | PATCH-BLOCK | Ensure Reverse Path Filtering is enabled"
   block:
-      - name: "3.3.7 | PATCH-SYSCTL.D | Ensure Reverse Path Filtering is enabled"
+      - name: "3.3.7 | PATCH-SYSCTL.D | Ensure Reverse Path Filtering is enabled - /etc"
         sysctl:
             name: "{{ item }}"
             value: '1'
             state: present
             ignoreerrors: yes
             sysctl_file: "/etc/sysctl.d/10-network-security.conf"
+        with_items:
+            - net.ipv4.conf.all.rp_filter
+            - net.ipv4.conf.default.rp_filter
+      - name: "3.3.7 | PATCH-SYSCTL.D | Ensure Reverse Path Filtering is enabled - /usr/lib/sysctl.d"
+        sysctl:
+            name: "{{ item }}"
+            value: '1'
+            state: present
+            ignoreerrors: yes
+            sysctl_file: "/usr/lib/sysctl.d/50-default.conf"
+        with_items:
+            - net.ipv4.conf.all.rp_filter
+            - net.ipv4.conf.default.rp_filter
+      - name: "3.3.7 | PATCH-SYSCTL.D | Ensure Reverse Path Filtering is enabled - /lib/sysctl.d"
+        sysctl:
+            name: "{{ item }}"
+            value: '1'
+            state: present
+            ignoreerrors: yes
+            sysctl_file: "/lib/sysctl.d/50-default.conf"
         with_items:
             - net.ipv4.conf.all.rp_filter
             - net.ipv4.conf.default.rp_filter

--- a/tasks/section_3/cis_3.3.x.yml
+++ b/tasks/section_3/cis_3.3.x.yml
@@ -165,18 +165,30 @@
       - icmp
       - sysctl
 
-- name: "3.3.7 | PATCH | Ensure Reverse Path Filtering is enabled"
-  sysctl:
-      name: "{{ item }}"
-      value: '1'
-      sysctl_set: yes
-      state: present
-      reload: yes
-      ignoreerrors: yes
-  with_items:
-      - net.ipv4.conf.all.rp_filter
-      - net.ipv4.conf.default.rp_filter
-  notify: sysctl flush ipv4 route table
+- name: "3.3.7 | PATCH-BLOCK | Ensure Reverse Path Filtering is enabled"
+  block:
+      - name: "3.3.7 | PATCH-SYSCTL.D | Ensure Reverse Path Filtering is enabled"
+        sysctl:
+            name: "{{ item }}"
+            value: '1'
+            state: present
+            ignoreerrors: yes
+            sysctl_file: "/etc/sysctl.d/10-network-security.conf"
+        with_items:
+            - net.ipv4.conf.all.rp_filter
+            - net.ipv4.conf.default.rp_filter
+      - name: "3.3.7 | PATCH-SYSCTL | Ensure Reverse Path Filtering is enabled"
+        sysctl:
+            name: "{{ item }}"
+            value: '1'
+            sysctl_set: yes
+            state: present
+            reload: yes
+            ignoreerrors: yes
+        with_items:
+            - net.ipv4.conf.all.rp_filter
+            - net.ipv4.conf.default.rp_filter
+        notify: sysctl flush ipv4 route table
   when:
       - ubtu22cis_rule_3_3_7
   tags:

--- a/tasks/section_4/cis_4.2.3.yml
+++ b/tasks/section_4/cis_4.2.3.yml
@@ -11,7 +11,7 @@
       - name: "4.2.3 | PATCH | Ensure all logfiles have appropriate permissions and ownership | Apply permissions and ownership"
         file:
             path: "{{ item.path }}"
-            mode: g-w,o-rwx
+            mode: g-w,u-rwx
         with_items:
             - "{{ ubtu22cis_4_2_3_logfiles.files }}"
         loop_control:

--- a/tasks/section_4/cis_4.2.3.yml
+++ b/tasks/section_4/cis_4.2.3.yml
@@ -11,7 +11,7 @@
       - name: "4.2.3 | PATCH | Ensure all logfiles have appropriate permissions and ownership | Apply permissions and ownership"
         file:
             path: "{{ item.path }}"
-            mode: g-w,u-rwx
+            mode: 0640
         with_items:
             - "{{ ubtu22cis_4_2_3_logfiles.files }}"
         loop_control:


### PR DESCRIPTION
**Overall Review of Changes:**
Further refinement of the role for `Level 1 - Server` use

**Issue Fixes:**
- Change `1.4.4` to default to `false` to prevent blind application of a plaintext root password into `/etc/shadow`
- Added additional files to patch for Reverse Path Forwarding based on CIS-CAT report assessment findings

**How has this been tested?:**
This role was used with an image building test bench and then evaluated using CIS-CAT Assessor v4.
